### PR TITLE
Update Conjure runtime to 46

### DIFF
--- a/data/io.github.nate_xyz.Conjure.appdata.xml.in
+++ b/data/io.github.nate_xyz.Conjure.appdata.xml.in
@@ -16,6 +16,8 @@
   <url type="homepage">https://github.com/nate-xyz/conjure</url>
   <url type="bugtracker">https://github.com/nate-xyz/conjure/issues</url>
   <url type="donation">https://ko-fi.com/natexyz</url>
+  <url type="vcs-browser">https://github.com/nate-xyz/conjure</url>
+  <url type="translate">https://github.com/nate-xyz/conjure/tree/main/po</url>
 
 	<releases>
     <release version="0.1.2" date="2023-04-02">
@@ -46,13 +48,8 @@
   </custom>
   <content_rating type="oars-1.1"/>
 
-	<categories>
-    <category>Graphics</category>
-    <category>ImageProcessing</category>
-  </categories>
-
 	<screenshots>
-    <screenshot>
+    <screenshot type="default">
       <image>https://raw.githubusercontent.com/nate-xyz/conjure/main/data/screenshots/conjure-0.png</image>
     </screenshot>
     <screenshot>

--- a/data/io.github.nate_xyz.Conjure.desktop.in
+++ b/data/io.github.nate_xyz.Conjure.desktop.in
@@ -6,7 +6,7 @@ Exec=conjure
 Icon=io.github.nate_xyz.Conjure
 Terminal=false
 Type=Application
-Categories=GNOME;GTK;Graphics
+Categories=Graphics;ImageProcessing;
 StartupNotify=true
 # Translators: Search terms to find this application. Do not translate or localize the semicolons! The list must also end with a semicolon.
 Keywords=image;magic;transform;

--- a/flatpak/imagemagick.json
+++ b/flatpak/imagemagick.json
@@ -12,8 +12,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://imagemagick.org/archive/releases/ImageMagick-7.1.0-62.tar.gz",
-            "sha256": "bcdc72ad8ffff2707dd54fc24992f6c31455bd1b1c3bd3f0defd9f3842e9623c",
+            "url": "https://imagemagick.org/archive/releases/ImageMagick-7.1.1-32.tar.gz",
+            "sha256": "c97e957f1eb6642669e535d6917599dc417c2f4ffcb4323f313d05dd40dc0ca4",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 1372,

--- a/flatpak/io.github.nate_xyz.Conjure.json
+++ b/flatpak/io.github.nate_xyz.Conjure.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nate_xyz.Conjure",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "conjure",
     "finish-args" : [


### PR DESCRIPTION
- runtime: Update runtime to 46
- depend: Update Imagemagick to 7.1.1-32
- Fix small appdata papercuts

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#categories-and-keywords